### PR TITLE
Added translation support for traditional Chinese 

### DIFF
--- a/locales/zh-hk
+++ b/locales/zh-hk
@@ -1,0 +1,217 @@
+{
+    "actions": {
+        "edit": "編輯",
+        "cancel": "取消",
+        "continue_shopping": "繼續購物",
+        "back_to_checkout": "前往付款",
+        "checkout": "付款",
+        "apply": "確認",
+        "type_address": "輸入地址",
+        "use_this_address": "使用此地址",
+        "back_to_store": "返回商店",
+        "close_cart": "關閉購物車",
+        "show": "顯示",
+        "hide": "隱藏",
+        "apply_changes": "更新"
+    },
+    "header": {
+        "title_cart_summary": "購物車",
+        "loading": "載入中..."
+    },
+    "item": {
+        "quantity": "數量",
+        "quantity_short": "數量",
+        "decrement_quantity": "減少數量",
+        "increment_quantity": "增加數量",
+        "remove_item": "移除此項目"
+    },
+    "cart": {
+        "subtotal": "小計",
+        "shipping_taxes_calculated_at_checkout": "運費將於付款時計算",
+        "loading": "我們正在更新您的購物車內容...",
+        "secured_by": "Secured by Snipcart",
+        "summary": "訂單內容",
+        "empty": "您的購物車中沒有商品",
+        "invoice_number": "訂單編號"
+    },
+    "order": {
+        "loading": "載入中..."
+    },
+    "discount_box": {
+        "promo_code": "優惠代碼?",
+        "promo_code_placeholder": "優惠代碼",
+        "promocode_applied": "優惠代碼已使用"
+    },
+    "address_form": {
+        "name": "全名",
+        "email": "電郵",
+        "address1": "地址1",
+        "address2": "地址2",
+        "city": "城市",
+        "country": "國家/地區",
+        "postalCode": "郵遞區號",
+        "province": "地區",
+        "dont_see_address": "沒有看到我的地址"
+    },
+    "billing": {
+        "title": "帳單地址",
+        "address": "帳單地址",
+        "continue_to_shipping": "確認",
+        "use_different_shipping_address": "如果你的帳單地址與收件地址不同﹐請選擇此項"
+    },
+    "customer": {
+        "information": "客戶資訊"
+    },
+    "customer_dashboard": {
+        "my_account": "我的帳號",
+        "ordered_on": "訂單成立於",
+        "total": "總計",
+        "status": "狀態",
+        "order": "訂單編號 %{invoice_number}",
+        "order_details": "訂單資訊",
+        "loading": "載入中...",
+        "no_orders": "尚無訂單",
+        "sign_out": "登出",
+        "show_more_orders": "再顯示 %{smart_count} 筆訂單 |||| 再顯示 %{smart_count} 筆訂單"
+    },
+    "signin_form": {
+        "signin": "登入",
+        "dont_have_an_account": "尚未成為會員?",
+        "email": "Email",
+        "password": "密碼",
+        "forgot_your_password": "忘記密碼?",
+        "close_form": "返回"
+    },
+    "register_form": {
+        "register": "註冊",
+        "already_have_an_account": "已經是會員?",
+        "email": "Email",
+        "password": "密碼",
+        "confirm_password": "確認密碼"
+    },
+    "guest_checkout": {
+        "or": "或",
+        "continue_as_a_guest": "以訪客身份繼續"
+    },
+    "shipping": {
+        "title": "寄送方式",
+        "shipping_to": "寄送至:",
+        "address": "寄送地址",
+        "method": "寄送方法"
+    },
+    "payment": {
+        "form":{
+            "card_label": "信用卡",
+            "card_number": "信用卡卡號",
+            "card_expiration": "信用卡到期：月份/年份",
+            "card_cvv": "CVV",
+            "card_postal_code": "郵遞區號"
+        },
+        "still_pending_notice": "您的付款正在處理中",
+        "title": "付款方式",
+        "continue_to_payment": "前往付款方式",
+        "credit_card": "信用卡到期日",
+        "place_order": "送出",
+        "preparing_payment_session": "付款中...",
+        "processing_payment": "付款中...",
+        "checkout_with": "結帳方式",
+        "checkout_with_method": "以 %{method} 做為結帳方式",
+        "method_icon": "%{method} 圖示",
+        "no_payment": "此筆訂單不需要付款",
+        "methods":{
+            "card": "結帳方式",
+            "paypal": "PayPal",
+            "paypal_express_checkout": "PayPal",
+            "apple_pay": "Apple Pay",
+            "bancontact": "Bancontact",
+            "belfius": "Belfius",
+            "eps": "Electronic Payment Standard",
+            "giropay": "Giropay",
+            "ideal": "iDEAL",
+            "ing_home_pay": "ING Home’Pay",
+            "kbc": "KBC",
+            "klarna_pay_later": "Klarna pay later",
+            "klarna_slice_it": "Klarna monthly financing",
+            "p24": "Przelewy24",
+            "sepa_debit": "SEPA bank transfer",
+            "sofort": "Sofort bank transfer"
+        }
+    },
+    "discounts": {
+      "title": "折扣"
+    },
+    "cart_summary": {
+      "total": "總計",
+      "subtotal": "小記",
+      "shipping": "運費",
+      "discount": "數量",
+      "quantity": "x"
+    },
+    "errors": {
+      "default": "發生錯誤，請稍等後再試一次或聯絡我們的客服人員",
+      "promo_code_is_invalid": "此優惠代碼無法使用",
+      "promocode_already_in_cart": "此優惠代碼已經被使用過了",
+      "promocode_isnt_applicable": "此優惠代碼無法使用",
+      "promo_code_is_expired": "此優惠代碼過期了",
+      "stringEmpty": "此項不得為空白",
+      "required": "此項為必填",
+      "invalid_expiry_year_past": "信用卡已過期",
+      "email": "請使用正確的 Email",
+      "quantity_revised": "由於庫存數目的關係，此筆訂單已被更新",
+      "quantity_out_of_stock": "很抱歉，此商品已無庫存，請從購物車移除後再繼續購物",
+      "error_payment_items_are_invalid": {
+          "title": "您購物車中的部分商品已無販售",
+          "description": "請查看您的訂單後再嘗試一次"
+      },
+      "order_validation":{
+        "domain_crawling":{
+            "title":"訂單無法處理",
+            "description":"您沒有被收款，如有問題麻煩請聯絡客服人員"
+        },
+        "product_crawling":{
+            "title":"您購物車內部分商品的價格已更新",
+            "description": "請試著移除此商品再重新加入購物車，如有問題麻煩請聯絡客服人員"
+        },
+        "stock_validation":{
+            "title":"此商品無足夠的庫存",
+            "description": "部分商品已無足夠的庫存，請修改訂購量後，如有問題麻煩請聯絡客服人員"
+        }
+      },
+      "shipping": {
+          "title": "無法計算運費",
+          "description": "請稍候重試，如有問題麻煩請聯絡客服人員"
+      },
+      "payment_failed": {
+          "title": "無法付款",
+          "description": "請稍候重試，如有問題麻煩請聯絡客服人員"
+      },
+      "payment_authorization": {
+          "title": "付款失敗",
+          "default": "請確認您的付款資訊，如有問題麻煩請聯絡客服人員"
+      },
+      "authentication_challenge": {
+        "failed": {
+            "title": "無法法處理付款",
+            "description": "我們無法處理您的付款，請您重試一次"
+        }
+      },
+      "customer_exists": "此 Email 已經被使用過了",
+      "customer_password_missmatch": "密碼不相符",
+      "invalid_credentials": "Email 或是密碼有誤",
+      "no_shipping_rates_found": {
+          "title": "無可用的寄送方式",
+          "description": "請確認您的地址，如有問題麻煩請聯絡客服人員"
+      }
+    },
+    "customer_orders": {
+        "loading": "載入中..."
+    },
+    "confirmation": {
+        "thank_you_for_your_order": "感謝您的訂購",
+        "async_confirmation_notice": "您的訂單已建立，系統正在處理中，訂單確認信將於不久後寄出"
+    },
+    "checkout": {
+        "shipping_taxes_calculated_when_address_provided": "系統將於輸入收件地址後計算出運費及稅金"
+    }
+}
+

--- a/locales/zh-hk
+++ b/locales/zh-hk
@@ -214,4 +214,3 @@
         "shipping_taxes_calculated_when_address_provided": "系統將於輸入收件地址後計算出運費及稅金"
     }
 }
-


### PR DESCRIPTION
This version uses the language code for traditional Chinese as used in Hong Kong (zh-hk).
This translation was provided by an experienced user of e-commerce and a native speaker and writer in traditional Chinese as used in Hong Kong