### PR TITLE
Replaced the German "ß" with the Swiss-German "ss"

### DIFF
--- a/locales/de-CH.json
+++ b/locales/de-CH.json
@@ -21,6 +21,7 @@
     },
     "address_form": {
         "email": "Email",
+        "address1": "Strasse",
         "address2": "Adresszusatz",
         "province": "Kanton"
     },


### PR DESCRIPTION
"...its use in modern typography is limited to the German language. In the 20th century, it fell out of use completely in Swiss Standard German (used in Switzerland and Liechtenstein)..."
Source: https://en.wikipedia.org/wiki/ß