### PR TITLE
DE: Rename address1 field label to include street nr

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -46,7 +46,7 @@
     "address_form": {
         "name": "Name",
         "email": "E-Mail",
-        "address1": "Straße",
+        "address1": "Straße und Hausnummer",
         "address2": "Adresse 2 (optional)",
         "city": "Stadt",
         "country": "Land",


### PR DESCRIPTION
In Germany a full address consists of
`street` `number`
`℅ optional second address line`
`5 digit zip code` `city`

It is very common for address forms to have separate fields for `street` and `number`. Since we don’t have that in Snipcart, the label for `address1` should indicate that both street and number go in there e.g. "Street and number", or in German "Straße und Hausnummer" or "Straße und Nr." in short