### PR TITLE
DE: Rename address2 field

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -47,7 +47,7 @@
         "name": "Name",
         "email": "E-Mail",
         "address1": "Straße",
-        "address2": "Adresse 2 (optional)",
+        "address2": "Adresszusatz (optional)",
         "city": "Stadt",
         "country": "Land",
         "postalCode": "Postleitzahl",


### PR DESCRIPTION
In Germany this information is most commonly referred to as "Additional address information" or in German "Addresszusatz". "Adresse 2" sounds like a secondary address and thus can be confusing because it is not a second address but more detailed info about the fish address.