### PR TITLE
New locales for flash message that appears when a payment retry fails when customer updates their payment method.

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -104,7 +104,11 @@
         "information": "Customer information",
         "payment_info": "My payment info",
         "payment_method_update":{
-            "title": "Payment method update"
+            "title": "Payment method update",
+            "outstanding_payment_failed": {
+                "title": "Payment failed",
+                "description": "Your payment method was updated, however, we were unable to charge the outstanding balance. Please use another payment method."
+            }
         }
     },
     "customer_details": {


### PR DESCRIPTION
When a customer has a recurring payment that fails, they must update their payment method and the payment will retry automatically. If it fails, we show a flash message on top of the payment method. This PR contains new locales for this component.