### PR TITLE
Update fr-FR.json

### DIFF
--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -60,7 +60,7 @@
     "promocode_applied": "Promotion appliquée"
   },
   "address_form": {
-    "name": "Nom complet",
+    "name": "Nom et prénom",
     "email": "Courriel",
     "address1": "Adresse postale",
     "address2": "Complément d’Adresse",


### PR DESCRIPTION
Remplacer "Nom complet" par "Nom et prénom", car la majorité des clients ne spécifient uniquement leur nom de famille, donc le prénom est manquant.