### PR TITLE
Updated de.json with missing strings & opted for informal form of address

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -1,4 +1,9 @@
 {
+    "default": {
+        "loading": "Laden...",
+        "error": "Es ist ein Fehler aufgetreten.",
+        "success": "Erfolg!"
+    },
     "actions": {
         "edit": "Bearbeiten",
         "cancel": "Abbrechen",
@@ -6,6 +11,7 @@
         "back_to_checkout": "Zurück zum Warenkorb",
         "checkout": "Zur Kasse",
         "apply": "Anwenden",
+        "dismiss": "Verwerfen",
         "type_address": "Eingabe deiner",
         "use_this_address": "Benutze diese Adresse",
         "back_to_store": "Zurück zum Shop",
@@ -15,8 +21,9 @@
         "apply_changes": "Änderungen übernehmen",
         "yes_use_it": "Ja, verwenden",
         "save_changes": "Änderungen speichern",
-        "back_to_orders": "Zurück zu Aufträgen",
-        "change_password": "Kennwort ändern",
+        "back_to_orders": "Zurück zu Bestellungen",
+        "change_password": "Passwort ändern",
+        "clear_cart": "Warenkorb leeren",
         "add": "Hinzufügen"
     },
     "header": {
@@ -26,8 +33,8 @@
     "item": {
         "quantity": "Anzahl",
         "quantity_short": "Anz",
-        "decrement_quantity": "Anzahl erhöhen",
-        "increment_quantity": "Anzahl reduzieren",
+        "decrement_quantity": "Anzahl reduzieren",
+        "increment_quantity": "Anzahl erhöhen",
         "remove_item": "Artikel löschen",
         "recurrence": {
             "daily": "Tag |||| %{smart_count} Tage",
@@ -37,27 +44,51 @@
         }
     },
     "subscription": {
+        "title": "Abonnement",
+        "state": {
+            "title": "Status",
+            "active": "Aktiv",
+            "paused": "Pausiert",
+            "finished": "Beendet",
+            "stopped": "Gestoppt",
+            "cancellationrequested": "Das Abonnement endet am Ende des Abrechnungszeitraums."
+        },
+        "placed_on": "Bestellt am",
+        "final_billing_date": "Endgültiges Rechnungsdatum",
+        "items": "Artikel",
         "plan": "Plan",
         "billed_on": "Berechnet am",
-        "payment_amount": "Zahlbetrag"
+        "payment_amount": "Zahlbetrag",
+        "processing": "Das Abonnement wird noch bearbeitet. Komm später wieder, um Details zu sehen.",
+        "loading": "Abonnements werden geladen",
+        "cancel": "Kündigen",
+        "pause": "Pausieren",
+        "unpause": "Fortsetzen",
+        "billing_recurrence": {
+            "daily": "Abrechnung jeden Tag |||| Abrechnung alle %{smart_count} Tage",
+            "weekly": "Abrechnung jede Woche |||| Abrechnung alle %{smart_count} Wochen",
+            "monthly": "Abrechnung jeden Monat |||| Abrechnung alle %{smart_count} Monate",
+            "yearly": "Abrechnung jedes Jahr |||| Abrechnung alle %{smart_count} Jahre"
+        }
     },
     "cart": {
         "subtotal": "Zwischensumme",
-        "shipping_taxes_calculated_at_checkout": "Versandkosten und Steuern werden an der Kasse berechnet",
+        "shipping_taxes_calculated_at_checkout": "Versandkosten und Steuern werden an der Kasse berechnet.",
         "loading": "Wir erstellen deinen Warenkorb...",
         "secured_by": "Verschlüsselt durch Snipcart",
         "summary": "Bestellübersicht",
-        "empty": "Dein Warenkorb ist leer",
+        "empty": "Dein Warenkorb ist leer.",
         "invoice_number": "Rechnungsnummer",
         "view_detailed_cart": "Warenkorb-Details anzeigen"
     },
     "order": {
-        "loading": "Wir laden deine Bestelldaten"
+        "loading": "Wir laden deine Bestelldaten...",
+        "title": "Bestellung"
     },
     "discount_box": {
-        "promo_code": "Gutschein ?",
+        "promo_code": "Gutschein?",
         "promo_code_placeholder": "Gutscheincode",
-        "promocode_applied": "Gutschein angenommen"
+        "promocode_applied": "Gutschein angewendet"
     },
     "address_form": {
         "name": "Name",
@@ -77,62 +108,85 @@
         "use_different_shipping_address": "Abweichende Versandadresse"
     },
     "customer": {
-        "information": "Kundeninformationen"
+        "information": "Kundeninformationen",
+        "payment_info": "Meine Zahlungsinformationen",
+        "payment_method_update": {
+            "title": "Aktualisierung der Zahlungsmethode",
+            "outstanding_payment_failed": {
+                "title": "Zahlung fehlgeschlagen",
+                "description": "Deine Zahlungsmethode wurde aktualisiert, wir konnten den ausstehenden Betrag jedoch nicht abbuchen. Bitte verwende eine andere Zahlungsmethode."
+            }
+        }
     },
     "customer_details": {
-        "title": "Kunde Details"
+        "title": "Kundendaten"
     },
     "customer_dashboard": {
         "my_account": "Mein Konto",
         "ordered_on": "Bestellt am",
-        "next_billing_date": "Nächste Rechnungstellung",
+        "next_billing_date": "Nächstes Abrechnungsdatum",
         "price": "Preis",
         "total": "Summe",
         "status": "Status",
         "order": "Bestellung %{invoice_number}",
         "order_details": "Bestelldetails",
         "loading": "Laden...",
-        "no_orders": "Keine Bestellungen vorhanden.",
+        "no_orders": "Keine Bestellungen gefunden.",
         "no_subscriptions": "Keine Abonnements gefunden.",
         "view_invoice": "Rechnung anzeigen",
         "sign_out": "Abmelden",
-        "show_more_orders": "%{smart_count} Bestellung mehr anzeigen |||| %{smart_count} Bestellungen mehr anzeigen",
-        "orders": "Bestellungen"
+        "show_more_orders": "%{smart_count} weitere Bestellung anzeigen |||| %{smart_count} weitere Bestellungen anzeigen",
+        "show_more_subscriptions": "%{smart_count} weiteres Abonnement anzeigen |||| %{smart_count} weitere Abonnements anzeigen",
+        "orders": "Bestellungen",
+        "subscriptions": "Abonnements",
+        "subscription": "Abonnement"
+    },
+    "customer_notifications": {
+        "subscription": {
+            "outstanding_payment": {
+                "title": "Für ein Abonnement ist eine Zahlung fällig",
+                "description": "Du hast derzeit ein Abonnement mit einer überfälligen Zahlung. Bitte aktualisiere deine Zahlungsmethode."
+            }
+        }
     },
     "signin_form": {
         "signin": "Anmelden",
         "dont_have_an_account": "Noch kein Konto?",
         "email": "E-Mail",
-        "password": "Kennwort",
-        "forgot_your_password": "Kennwort vergessen?",
+        "password": "Passwort",
+        "forgot_your_password": "Passwort vergessen?",
         "close_form": "Zurück"
     },
     "forgot_password_form": {
-        "title": "Kennwort zurücksetzen",
-        "instructions": "Geben Sie die E-Mail-Adresse Ihres Kontos ein und wir senden Ihnen einen Link zum Zurücksetzen des Kennworts.",
+        "title": "Passwort zurücksetzen",
+        "instructions": "Gib die E-Mail-Adresse deines Kontos ein, und wir senden dir einen Link zum Zurücksetzen des Passworts.",
         "email": "E-Mail",
-        "email_instructions": "Eine E-Mail mit einem Link wurde an Sie geschickt. Klicken Sie darauf, um Ihr Kennwort zurückzusetzen.",
+        "email_instructions": "Du hast eine E-Mail mit einem Link erhalten. Klicke auf diesen Link, um dein Passwort zurückzusetzen.",
         "action": "E-Mail zum Zurücksetzen senden"
     },
     "reset_password_form": {
-        "title": "Kennwort zurücksetzen",
-        "password": "Neues Kennwort",
-        "confirmation_password": "Neues Kennwort wiederholen",
-        "action": "Kennwort zurücksetzen"
+        "title": "Passwort zurücksetzen",
+        "password": "Neues Passwort",
+        "confirmation_password": "Neues Passwort wiederholen",
+        "action": "Passwort zurücksetzen"
     },
     "change_password_form": {
-        "title": "Kennwort ändern",
-        "current_password": "Aktuelles Kennwort",
-        "password": "Neues Kennwort",
-        "confirmation_password": "Kennwort erneut eingeben",
-        "action": "Kennwort ändern"
+        "title": "Passwort ändern",
+        "current_password": "Aktuelles Passwort",
+        "password": "Neues Passwort",
+        "confirmation_password": "Neues Passwort erneut eingeben",
+        "action": "Passwort ändern"
     },
     "register_form": {
         "register": "Registrieren",
-        "already_have_an_account": "Sie haben bereits ein Konto?",
+        "already_have_an_account": "Du hast bereits ein Konto?",
         "email": "E-Mail",
-        "password": "Kennwort",
-        "confirm_password": "Kennwort bestätigen"
+        "password": "Passwort",
+        "confirm_password": "Passwort bestätigen",
+        "requires_action": {
+            "title": "Überprüfe deine E-Mails",
+            "description": "Diese E-Mail-Adresse wurde bereits für eine Bestellung verwendet. Bitte schließe den Registrierungsprozess ab, indem du den Link verwendest, der dir per E-Mail zugesandt wurde."
+        }
     },
     "guest_checkout": {
         "or": "oder",
@@ -142,19 +196,29 @@
         "title": "Versand",
         "shipping_to": "Versand nach:",
         "address": "Versandadresse",
-        "method": "Versandmethode"
+        "method": "Versandmethode",
+        "methods": {
+            "example_localization_id": "Dies ist ein Beispiel für eine lokalisierte Versandmethode"
+        }
+    },
+    "shipping_rates": {
+        "guaranteed_delivery_days": "Garantiert zugestellt in %{guaranteedDaysToDelivery} Tag(en)."
     },
     "payment": {
         "form": {
             "deferred_payment_title": "Später zahlen",
-            "deferred_payment_instructions": "Mit dieser Bestellung erklären Sie sich damit einverstanden, später über die vom Händler angegebene Zahlungsmethode zu zahlen.",
+            "deferred_payment_instructions": "Mit dieser Bestellung erklärst du dich damit einverstanden, später über die vom Händler angegebene Zahlungsmethode zu zahlen.",
             "card_label": "Kreditkarte",
             "card_number": "Kartennummer",
             "card_expiration": "MM/JJ",
             "card_cvv": "CVV",
-            "card_postal_code": "Postleitzahl"
+            "card_postal_code": "Postleitzahl",
+            "invalid_number": "Kartennummer ist ungültig",
+            "invalid_expiration": "Ablaufdatum ist ungültig",
+            "invalid_cvv": "CVV ist ungültig",
+            "invalid_postal_code": "Postleitzahl ist ungültig"
         },
-        "still_pending_notice": "Ihre Zahlung ist noch in der Bearbeitung.",
+        "still_pending_notice": "Deine Zahlung wird noch bearbeitet.",
         "title": "Zahlungsmethode",
         "continue_to_payment": "Weiter zur Zahlungsmethode",
         "credit_card": "Kreditkarte",
@@ -175,10 +239,10 @@
             "eps": "Electronic Payment Standard",
             "giropay": "Giropay",
             "ideal": "iDEAL",
-            "ing_home_pay": "ING Home Pay",
+            "ing_home_pay": "ING Home'Pay",
             "kbc": "KBC",
-            "klarna_pay_later": "Auf Rechnung",
-            "klarna_slice_it": "Ratenzahlung",
+            "klarna_pay_later": "Klarna Rechnung",
+            "klarna_slice_it": "Klarna Ratenzahlung",
             "p24": "Przelewy24",
             "sepa_debit": "Lastschrift",
             "sofort": "Sofortüberweisung",
@@ -198,21 +262,22 @@
         "quantity": "x"
     },
     "errors": {
-        "default": "Es ist ein Fehler aufgetreten, versuchen Sie es später erneut oder kontaktieren Sie uns.",
+        "default": "Es ist ein Fehler aufgetreten, versuche es später erneut oder kontaktiere uns.",
         "promo_code_is_invalid": "Dieser Gutscheincode ist nicht gültig",
         "promocode_already_in_cart": "Dieser Gutscheincode wurde bereits angewandt",
         "promocode_isnt_applicable": "Dieser Gutscheincode ist für diese Artikel nicht gültig",
-        "promo_code_is_expired": "Diese Aktion ist ausgelaufen",
+        "promo_code_is_expired": "Dieser Gutscheincode ist abgelaufen",
         "stringEmpty": "Dieses Feld darf nicht leer sein",
+        "emailEmpty": "Dieses Feld wird benötigt",
         "required": "Dies ist ein Pflichtfeld",
-        "invalid_expiry_year_past": "Diese Karte ist bereits abgelaufen",
+        "invalid_expiry_year_past": "Karte ist abgelaufen",
         "email": "Diese E-Mail-Adresse ist ungültig",
         "quantity_revised": "Die Anzahl wurde aufgrund von Lagerbeschränkungen überarbeitet.",
-        "quantity_out_of_stock": "Leider ist dieser Artikel nicht mehr vorrätig. Nehmen Sie ihn aus dem Warenkorb, um fortzufahren.",
+        "quantity_out_of_stock": "Leider ist dieser Artikel nicht mehr vorrätig. Entferne ihn aus dem Warenkorb, um fortzufahren.",
         "disabled_country": "Leider ist eine Bestellung für das gewählte Land nicht möglich.",
         "error_payment_items_are_invalid": {
-            "title": "Einige Artikel in Ihrem Warenkorb sind ungültig",
-            "description": "Bitte überprüfen Sie Ihre Bestellung oder versuchen Sie es später erneut."
+            "title": "Einige Artikel in deinem Warenkorb sind ungültig",
+            "description": "Bitte überprüfe deine Bestellung oder versuche es später erneut."
         },
         "card": {
             "invalid_number": "Die Kartenummer ist ungültig.",
@@ -222,83 +287,855 @@
             "invalid_cvv": "Der CVV der Karte ist ungültig.",
             "invalid_expiration": "Das Ablaufdatum der Karte ist ungültig.",
             "expired": "Die Kreditkarte ist abgelaufen",
-            "declined": "Die Karte wurde abgelehnt. Bitte rufen Sie Ihren Kartenaussteller an, um weitere Informationen zu erhalten.",
+            "declined": "Die Karte wurde abgelehnt. Bitte wende dich an deinen Kartenaussteller, um weitere Informationen zu erhalten.",
             "invalid_address": "Die Adresse der Karte ist falsch.",
             "insufficient_funds": "Das Konto verfügt nicht über ausreichende Mittel, um den Transaktionsbetrag zu decken.",
-            "card_not_supported": "Die Karte wird in der Region nicht unterstützt.",
-            "currency_not_supported": "The currency is not currently supported."
+            "card_not_supported": "Die Karte wird in dieser Region nicht unterstützt.",
+            "currency_not_supported": "Die Währung wird derzeit nicht unterstützt."
         },
         "transaction": {
-            "declined": "Bei der Verarbeitung der Karte ist ein Fehler aufgetreten. Versuchen Sie es später noch einmal oder mit einer anderen Zahlungsmethode."
+            "declined": "Bei der Verarbeitung der Karte ist ein Fehler aufgetreten. Versuche es später noch einmal oder mit einer anderen Zahlungsmethode."
         },
         "discounts": {
-            "conflict": "Einige Rabatte können nicht kombiniert werden. Nutzen Sie stattdessen diesen Rabatt?"
+            "conflict": "Einige Rabatte können nicht kombiniert werden. Stattdessen diesen Rabatt nutzen?"
         },
         "order_validation": {
             "domain_crawling": {
                 "title": "Bestellung konnte nicht bearbeitet werden.",
-                "description": "Sie wurden nicht belastet. Bitte kontaktieren Sie den Shop-Besitzer für Details."
+                "description": "Deine Zahlungsmethode wurde nicht belastet. Bitte wende dich an den Shop-Betreiber, um weitere Informationen zu erhalten."
             },
             "product_crawling": {
                 "title": "Der Preis der Produkte im Warenkorb hat sich möglicherweise geändert.",
-                "description": "Versuchen Sie, die Produkte zu entfernen und dann erneut in Ihren Warenkorb zu legen. Bitte kontaktieren Sie den Shop-Besitzer für Details."
+                "description": "Versuche, sie zu entfernen und wieder in den Warenkorb zu legen. Bitte wende dich an den Shop-Betreiber, um weitere Informationen zu erhalten."
             },
             "stock_validation": {
                 "title": "Produktbestand nicht verfügbar.",
-                "description": "Einige Produkte sind in der ausgewählte Anzahl möglicherweise nicht vorrätig. Überarbeiten Sie die Anzahl oder wenden Sie sich an den Shop-Besitzer, um weitere Informationen zu erhalten."
+                "description": "Einige Produkte sind in der ausgewählte Anzahl möglicherweise nicht vorrätig. Überarbeite die Anzahl oder wende dich an den Shop-Betreiber, um weitere Informationen zu erhalten."
             },
             "custom_fields_validation": {
                 "title": "Fehlende erforderliche Informationen.",
-                "description": "Bei einigen Produkten im Warenkorb fehlen Pflichtangaben. Bitte bearbeiten Sie den Warenkorb, um fortzufahren."
+                "description": "Bei einigen Produkten im Warenkorb fehlen Pflichtangaben. Bitte bearbeite den Warenkorb, um fortzufahren."
             },
             "shipping_validation": {
                 "title": "Die Versandmethode konnte nicht validiert werden.",
-                "description": "Der ausgewählte Versandtarif hat sich möglicherweise geändert oder ist nicht verfügbar. Bitte kontaktieren Sie den Ladenbesitzer für Einzelheiten."
+                "description": "Der gewählte Versandtarif hat sich möglicherweise geändert oder ist nicht mehr verfügbar. Bitte wende dich an den Shop-Betreiber, um weitere Informationen zu erhalten."
             }
         },
         "shipping": {
             "account_configuration": {
                 "title": "Derzeit ist keine Versandmethode verfügbar",
-                "description": "Versuchen Sie es später noch einmal, oder kontaktieren Sie uns für Unterstützung."
+                "description": "Versuche es später noch einmal, oder wende dich an unseren Support."
             },
             "rates_calculation": {
-                "title": "Versandkosten für Ihre Bestellung können nicht berechnet werden",
-                "description": "Versuchen Sie es später noch einmal, oder kontaktieren Sie uns für Unterstützung."
+                "title": "Versandkosten für deine Bestellung können nicht berechnet werden",
+                "description": "Versuche es später noch einmal, oder wende dich an unseren Support."
             },
             "no_rates_found": {
-                "title": "Für Ihre Bestellung sind keine Versandmethoden verfügbar.",
-                "description": "Bitte überprüfen Sie Ihre Lieferadresse oder kontaktieren Sie uns."
+                "title": "Für deine Bestellung sind keine Versandmethoden verfügbar.",
+                "description": "Bitte überprüfe deine Lieferadresse oder wende dich an unseren Support."
             }
         },
         "payment_failed": {
-            "title": "Die Zahlung konnte nicht duchgeführt werden",
-            "description": "Versuchen Sie es später erneut oder kontaktieren Sie unseren Support."
+            "title": "Zahlung konnte nicht duchgeführt werden",
+            "description": "Versuche es später erneut oder wende dich an unseren Support."
         },
         "payment_authorization": {
-            "title": "Ihre Zahlung konnte nicht verarbeitet werden",
-            "default": "Bitte überprüfen Sie Ihre Angaben"
+            "title": "Zahlung konnte nicht verarbeitet werden",
+            "default": "Bitte überprüfe deine Angaben"
         },
         "authentication_challenge": {
             "failed": {
-                "title": "Die Zahlung konnte nicht duchgeführt werden",
-                "description": "Wir konnten Ihre Zahlungsinformationen nicht authentifizieren. Bitte versuchen Sie es erneut."
+                "title": "Zahlung konnte nicht duchgeführt werden",
+                "description": "Wir konnten deine Zahlungsinformationen nicht authentifizieren. Bitte versuche es erneut"
+            }
+        },
+        "cart_items": {
+            "cart_can_only_contain_one_subscription": {
+                "title": "Abonnement konnte nicht in den Warenkorb gelegt werden",
+                "description": "Ein Warenkorb kann jeweils nur ein Abonnement enthalten."
+            },
+            "cart_can_only_contain_items_or_subscriptions": {
+                "title": "Produkt konnte nicht in den Warenkorb gelegt werden",
+                "description": "Der Warenkorb kann nur entweder Artikel oder ein Abonnement enthalten."
             }
         },
         "customer_exists": "Diese E-Mail-Adresse wird bereits verwendet.",
         "customer_password_missmatch": "Die beiden Kennwörter müssen übereinstimmen.",
-        "customer_password_token_expired": "Der Wiederherstellungs-Token für Ihr Kennwort ist abgelaufen.",
-        "customer_password_token_invalid": "Der Wiederherstellungs-Token für Ihr Kennwort ist ungültig.",
+        "customer_password_token_expired": "Der Wiederherstellungs-Token für dein Passwort ist abgelaufen.",
+        "customer_password_token_invalid": "Der Wiederherstellungs-Token für dein Passwort ist ungültig.",
         "customer_not_found": "Die E-Mail-Adresse konnte keinem Konto zugeordnet werden.",
-        "invalid_credentials": "Ungültige E-Mail-Adresse oder Kennwort."
+        "invalid_credentials": "Ungültige E-Mail-Adresse oder Passwort.",
+        "customer_current_password_invalid": "Ungültiges Passwort."
+    },
+    "shippingRates": {
+        "loading": "Versandkosten werden geladen"
     },
     "customer_orders": {
         "loading": "Laden..."
     },
+    "digital_goods": {
+        "download": "Datei herunterladen"
+    },
     "confirmation": {
-        "thank_you_for_your_order": "Vielen Dank für Ihre Bestellung",
-        "async_confirmation_notice": "Ihre Bestellung wird jetzt bearbeitet. Sie erhalten in Kürze eine Bestätigung per E-Mail."
+        "thank_you_for_your_order": "Vielen Dank für deine Bestellung",
+        "async_confirmation_notice": "Deine Bestellung wird jetzt bearbeitet. Du erhältst in Kürze eine Bestätigung per E-Mail."
     },
     "checkout": {
-        "shipping_taxes_calculated_when_address_provided": "Die Versandkosten und Steuern werden nach Eingabe der Versandadresse berechnet"
+        "shipping_taxes_calculated_when_address_provided": "Versandkosten und Steuern werden nach Eingabe der Versandadresse berechnet."
+    },
+    "countries": {
+        "AD": {
+            "name": "Andorra"
+        },
+        "AE": {
+            "name": "Vereinigte Arabische Emirate"
+        },
+        "AF": {
+            "name": "Afghanistan"
+        },
+        "AG": {
+            "name": "Antigua und Barbuda"
+        },
+        "AI": {
+            "name": "Anguilla"
+        },
+        "AL": {
+            "name": "Albanien"
+        },
+        "AM": {
+            "name": "Armenien"
+        },
+        "AO": {
+            "name": "Angola"
+        },
+        "AQ": {
+            "name": "Antarktis"
+        },
+        "AR": {
+            "name": "Argentinien"
+        },
+        "AS": {
+            "name": "Amerikanisch-Samoa"
+        },
+        "AT": {
+            "name": "Österreich"
+        },
+        "AU": {
+            "name": "Australien"
+        },
+        "AW": {
+            "name": "Aruba"
+        },
+        "AX": {
+            "name": "Aland"
+        },
+        "AZ": {
+            "name": "Aserbaidschan"
+        },
+        "BA": {
+            "name": "Bosnien und Herzegowina"
+        },
+        "BB": {
+            "name": "Barbados"
+        },
+        "BD": {
+            "name": "Bangladesch"
+        },
+        "BE": {
+            "name": "Belgien"
+        },
+        "BF": {
+            "name": "Burkina Faso"
+        },
+        "BG": {
+            "name": "Bulgarien"
+        },
+        "BH": {
+            "name": "Bahrain"
+        },
+        "BI": {
+            "name": "Burundi"
+        },
+        "BJ": {
+            "name": "Benin"
+        },
+        "BL": {
+            "name": "St. Barthélemy"
+        },
+        "BM": {
+            "name": "Bermuda"
+        },
+        "BN": {
+            "name": "Brunei"
+        },
+        "BO": {
+            "name": "Bolivien"
+        },
+        "BQ": {
+            "name": "Bonaire"
+        },
+        "BR": {
+            "name": "Brasilien"
+        },
+        "BS": {
+            "name": "Bahamas"
+        },
+        "BT": {
+            "name": "Bhutan"
+        },
+        "BV": {
+            "name": "Bouvetinsel"
+        },
+        "BW": {
+            "name": "Botswana"
+        },
+        "BY": {
+            "name": "Belarus"
+        },
+        "BZ": {
+            "name": "Belize"
+        },
+        "CA": {
+            "name": "Kanada"
+        },
+        "CC": {
+            "name": "Kokosinseln"
+        },
+        "CD": {
+            "name": "Kongo"
+        },
+        "CF": {
+            "name": "Zentralafrikanische Republik"
+        },
+        "CG": {
+            "name": "Republik Kongo"
+        },
+        "CH": {
+            "name": "Schweiz"
+        },
+        "CI": {
+            "name": "Elfenbeinküste"
+        },
+        "CK": {
+            "name": "Cookinseln"
+        },
+        "CL": {
+            "name": "Chile"
+        },
+        "CM": {
+            "name": "Kamerun"
+        },
+        "CN": {
+            "name": "China"
+        },
+        "CO": {
+            "name": "Kolumbien"
+        },
+        "CR": {
+            "name": "Costa Rica"
+        },
+        "CU": {
+            "name": "Kuba"
+        },
+        "CV": {
+            "name": "Kap Verde"
+        },
+        "CW": {
+            "name": "Curacao"
+        },
+        "CX": {
+            "name": "Weihnachtsinsel"
+        },
+        "CY": {
+            "name": "Zypern"
+        },
+        "CZ": {
+            "name": "Tschechien"
+        },
+        "DE": {
+            "name": "Deutschland"
+        },
+        "DJ": {
+            "name": "Dschibuti"
+        },
+        "DK": {
+            "name": "Dänemark"
+        },
+        "DM": {
+            "name": "Dominica"
+        },
+        "DO": {
+            "name": "Dominikanische Republik"
+        },
+        "DZ": {
+            "name": "Algerien"
+        },
+        "EC": {
+            "name": "Ecuador"
+        },
+        "EE": {
+            "name": "Estland"
+        },
+        "EG": {
+            "name": "Ägypten"
+        },
+        "EH": {
+            "name": "Westsahara"
+        },
+        "ER": {
+            "name": "Eritrea"
+        },
+        "ES": {
+            "name": "Spanien"
+        },
+        "ES-CN": {
+            "name": "Kanarische Inseln"
+        },
+        "ET": {
+            "name": "Äthiopien"
+        },
+        "FI": {
+            "name": "Finnland"
+        },
+        "FJ": {
+            "name": "Fidschi"
+        },
+        "FK": {
+            "name": "Falklandinseln"
+        },
+        "FM": {
+            "name": "Mikronesien"
+        },
+        "FO": {
+            "name": "Färöer Inseln"
+        },
+        "FR": {
+            "name": "Frankreich"
+        },
+        "GA": {
+            "name": "Gabun"
+        },
+        "GB": {
+            "name": "Vereinigtes Königreich"
+        },
+        "GD": {
+            "name": "Grenada"
+        },
+        "GE": {
+            "name": "Georgien"
+        },
+        "GF": {
+            "name": "Französisch-Guayana"
+        },
+        "GG": {
+            "name": "Guernsey"
+        },
+        "GH": {
+            "name": "Ghana"
+        },
+        "GI": {
+            "name": "Gibraltar"
+        },
+        "GL": {
+            "name": "Grönland"
+        },
+        "GM": {
+            "name": "Gambia"
+        },
+        "GN": {
+            "name": "Guinea"
+        },
+        "GP": {
+            "name": "Guadeloupe"
+        },
+        "GQ": {
+            "name": "Äquatorialguinea"
+        },
+        "GR": {
+            "name": "Griechenland"
+        },
+        "GS": {
+            "name": "Südgeorgien und die Südlichen Sandwichinseln"
+        },
+        "GT": {
+            "name": "Guatemala"
+        },
+        "GU": {
+            "name": "Guam"
+        },
+        "GW": {
+            "name": "Guinea-Bissau"
+        },
+        "GY": {
+            "name": "Guyana"
+        },
+        "HK": {
+            "name": "Hongkong"
+        },
+        "HM": {
+            "name": "Heard und McDonaldinseln"
+        },
+        "HN": {
+            "name": "Honduras"
+        },
+        "HR": {
+            "name": "Kroatien"
+        },
+        "HT": {
+            "name": "Haiti"
+        },
+        "HU": {
+            "name": "Ungarn"
+        },
+        "ID": {
+            "name": "Indonesien"
+        },
+        "IE": {
+            "name": "Irland"
+        },
+        "IL": {
+            "name": "Israel"
+        },
+        "IM": {
+            "name": "Isle of Man"
+        },
+        "IN": {
+            "name": "Indien"
+        },
+        "IO": {
+            "name": "Britisches Territorium im Indischen Ozean"
+        },
+        "IQ": {
+            "name": "Irak"
+        },
+        "IR": {
+            "name": "Iran"
+        },
+        "IS": {
+            "name": "Island"
+        },
+        "IT": {
+            "name": "Italien"
+        },
+        "JE": {
+            "name": "Jersey"
+        },
+        "JM": {
+            "name": "Jamaika"
+        },
+        "JO": {
+            "name": "Jordanien"
+        },
+        "JP": {
+            "name": "Japan"
+        },
+        "KE": {
+            "name": "Kenia"
+        },
+        "KG": {
+            "name": "Kirgisistan"
+        },
+        "KH": {
+            "name": "Kambodscha"
+        },
+        "KI": {
+            "name": "Kiribati"
+        },
+        "KM": {
+            "name": "Komoren"
+        },
+        "KN": {
+            "name": "St. Kitts und Nevis"
+        },
+        "KP": {
+            "name": "Nordkorea"
+        },
+        "KR": {
+            "name": "Südkorea"
+        },
+        "KW": {
+            "name": "Kuwait"
+        },
+        "KY": {
+            "name": "Kaimaninseln"
+        },
+        "KZ": {
+            "name": "Kasachstan"
+        },
+        "LA": {
+            "name": "Laos"
+        },
+        "LB": {
+            "name": "Libanon"
+        },
+        "LC": {
+            "name": "St. Lucia"
+        },
+        "LI": {
+            "name": "Liechtenstein"
+        },
+        "LK": {
+            "name": "Sri Lanka"
+        },
+        "LR": {
+            "name": "Liberia"
+        },
+        "LS": {
+            "name": "Lesotho"
+        },
+        "LT": {
+            "name": "Litauen"
+        },
+        "LU": {
+            "name": "Luxemburg"
+        },
+        "LV": {
+            "name": "Lettland"
+        },
+        "LY": {
+            "name": "Libyen"
+        },
+        "MA": {
+            "name": "Marokko"
+        },
+        "MC": {
+            "name": "Monaco"
+        },
+        "MD": {
+            "name": "Moldawien"
+        },
+        "ME": {
+            "name": "Montenegro"
+        },
+        "MF": {
+            "name": "St. Martin"
+        },
+        "MG": {
+            "name": "Madagaskar"
+        },
+        "MH": {
+            "name": "Marshallinseln"
+        },
+        "MK": {
+            "name": "Mazedonien"
+        },
+        "ML": {
+            "name": "Mali"
+        },
+        "MM": {
+            "name": "Myanmar (Burma]"
+        },
+        "MN": {
+            "name": "Mongolei"
+        },
+        "MO": {
+            "name": "Macao"
+        },
+        "MP": {
+            "name": "Nördliche Marianneninseln"
+        },
+        "MQ": {
+            "name": "Martinique"
+        },
+        "MR": {
+            "name": "Mauretanien"
+        },
+        "MS": {
+            "name": "Montserrat"
+        },
+        "MT": {
+            "name": "Malta"
+        },
+        "MU": {
+            "name": "Mauritius"
+        },
+        "MV": {
+            "name": "Malediven"
+        },
+        "MW": {
+            "name": "Malawi"
+        },
+        "MX": {
+            "name": "Mexiko"
+        },
+        "MY": {
+            "name": "Malaysia"
+        },
+        "MZ": {
+            "name": "Mosambik"
+        },
+        "NA": {
+            "name": "Namibia"
+        },
+        "NC": {
+            "name": "Neukaledonien"
+        },
+        "NE": {
+            "name": "Niger"
+        },
+        "NF": {
+            "name": "Norfolkinsel"
+        },
+        "NG": {
+            "name": "Nigeria"
+        },
+        "NI": {
+            "name": "Nicaragua"
+        },
+        "NL": {
+            "name": "Niederlande"
+        },
+        "NO": {
+            "name": "Norwegen"
+        },
+        "NP": {
+            "name": "Nepal"
+        },
+        "NR": {
+            "name": "Nauru"
+        },
+        "NU": {
+            "name": "Niue"
+        },
+        "NZ": {
+            "name": "Neuseeland"
+        },
+        "OM": {
+            "name": "Oman"
+        },
+        "PA": {
+            "name": "Panama"
+        },
+        "PE": {
+            "name": "Peru"
+        },
+        "PF": {
+            "name": "Französisch-Polynesien"
+        },
+        "PG": {
+            "name": "Papua-Neuguinea"
+        },
+        "PH": {
+            "name": "Philippinen"
+        },
+        "PK": {
+            "name": "Pakistan"
+        },
+        "PL": {
+            "name": "Polen"
+        },
+        "PM": {
+            "name": "Saint Pierre und Miquelon"
+        },
+        "PN": {
+            "name": "Pitcairninseln"
+        },
+        "PR": {
+            "name": "Puerto Rico"
+        },
+        "PS": {
+            "name": "Palästina"
+        },
+        "PT": {
+            "name": "Portugal"
+        },
+        "PW": {
+            "name": "Palau"
+        },
+        "PY": {
+            "name": "Paraguay"
+        },
+        "QA": {
+            "name": "Katar"
+        },
+        "RE": {
+            "name": "Réunion"
+        },
+        "RO": {
+            "name": "Rumänien"
+        },
+        "RS": {
+            "name": "Serbien"
+        },
+        "RU": {
+            "name": "Russland"
+        },
+        "RW": {
+            "name": "Ruanda"
+        },
+        "SA": {
+            "name": "Saudi-Arabien"
+        },
+        "SB": {
+            "name": "Salomoninseln"
+        },
+        "SC": {
+            "name": "Seychellen"
+        },
+        "SD": {
+            "name": "Sudan"
+        },
+        "SE": {
+            "name": "Schweden"
+        },
+        "SG": {
+            "name": "Singapur"
+        },
+        "SH": {
+            "name": "Sankt Helena"
+        },
+        "SI": {
+            "name": "Slowenien"
+        },
+        "SJ": {
+            "name": "Spitzbergen und Jan Mayen"
+        },
+        "SK": {
+            "name": "Slowakei"
+        },
+        "SL": {
+            "name": "Sierra Leone"
+        },
+        "SM": {
+            "name": "San Marino"
+        },
+        "SN": {
+            "name": "Senegal"
+        },
+        "SO": {
+            "name": "Somalia"
+        },
+        "SR": {
+            "name": "Surinam"
+        },
+        "SS": {
+            "name": "Südsudan"
+        },
+        "ST": {
+            "name": "São Tomé und Príncipe"
+        },
+        "SV": {
+            "name": "El Salvador"
+        },
+        "SX": {
+            "name": "Sint Maarten"
+        },
+        "SY": {
+            "name": "Syrien"
+        },
+        "SZ": {
+            "name": "Swasiland"
+        },
+        "TC": {
+            "name": "Turks- und Caicosinseln"
+        },
+        "TD": {
+            "name": "Chad"
+        },
+        "TF": {
+            "name": "Französische Süd-Territorien"
+        },
+        "TG": {
+            "name": "Togo"
+        },
+        "TH": {
+            "name": "Thailand"
+        },
+        "TJ": {
+            "name": "Tadschikistan"
+        },
+        "TK": {
+            "name": "Tokelau"
+        },
+        "TL": {
+            "name": "Osttimor"
+        },
+        "TM": {
+            "name": "Turkmenistan"
+        },
+        "TN": {
+            "name": "Tunesien"
+        },
+        "TO": {
+            "name": "Tonga"
+        },
+        "TR": {
+            "name": "Türkei"
+        },
+        "TT": {
+            "name": "Trinidad und Tobago"
+        },
+        "TV": {
+            "name": "Tuvalu"
+        },
+        "TW": {
+            "name": "Taiwan"
+        },
+        "TZ": {
+            "name": "Tansania"
+        },
+        "UA": {
+            "name": "Ukraine"
+        },
+        "UG": {
+            "name": "Uganda"
+        },
+        "UM": {
+            "name": "U.S. Minor Outlying Islands"
+        },
+        "US": {
+            "name": "USA"
+        },
+        "UY": {
+            "name": "Uruguay"
+        },
+        "UZ": {
+            "name": "Usbekistan"
+        },
+        "VA": {
+            "name": "Vatikanstadt"
+        },
+        "VC": {
+            "name": "St. Vincent und die Grenadinen"
+        },
+        "VE": {
+            "name": "Venezuela"
+        },
+        "VG": {
+            "name": "Britische Jungferninseln"
+        },
+        "VI": {
+            "name": "U.S. Jungferninseln"
+        },
+        "VN": {
+            "name": "Vietnam"
+        },
+        "VU": {
+            "name": "Vanuatu"
+        },
+        "WF": {
+            "name": "Wallis und Futuna"
+        },
+        "WS": {
+            "name": "Samoa"
+        },
+        "XK": {
+            "name": "Kosovo"
+        },
+        "YE": {
+            "name": "Jemen"
+        },
+        "YT": {
+            "name": "Mayotte"
+        },
+        "ZA": {
+            "name": "Südafrika"
+        },
+        "ZM": {
+            "name": "Sambia"
+        },
+        "ZW": {
+            "name": "Zimbabwe"
+        }
     }
 }


### PR DESCRIPTION
Added and translated missing strings from en.json and fixed some typos and mistranslations.

German has a formal and informal form of address (du / Sie), just like French has (tu / vous).
The current translations were a mix of formal and informal. I opted for informal for now, as it seems more modern and approachable to me.
But I'm open to change it to formal and use a custom informal version on my own instance. Let me know.
(One day it would be nice to have a `de-formal.json` and `de-informal.json` with a switch in the settings.)

Oh, and also changed "Kennwort" to the more commonly used "Passwort".