### PR TITLE
Fix typo in SL locale for place_order

### DIFF
--- a/locales/sl.json
+++ b/locales/sl.json
@@ -216,7 +216,7 @@
         "title": "Plačilo",
         "continue_to_payment": "Nadaljuj na plačilo",
         "credit_card": "Kreditna kartica",
-        "place_order": "Zakjuči plačilo",
+        "place_order": "Zaključi plačilo",
         "preparing_payment_session": "Priprava plačila...",
         "processing_payment": "Obdelava plačila...",
         "checkout_with": "Način plačila",


### PR DESCRIPTION
This PR addresses a typo in the SL locale.