### PR TITLE
Cart summary and billing

### DIFF
--- a/locales/kz.json
+++ b/locales/kz.json
@@ -104,7 +104,7 @@
         "dont_see_address": "Мекенжайымды таба алмадым"
     },
     "billing": {
-        "title": "Төлем",
+        "title": "Төлем ақпараты",
         "address": "Төлем мекенжайы",
         "continue_to_shipping": "Жеткізуге өту",
         "use_different_shipping_address": "Басқа жеткізу мекенжайын пайдалану"


### PR DESCRIPTION
Added a previously missing translation of 'Cart summary' and replaced the word for Billing to not be the same as Payment.