### PR TITLE
Update Finnish localization strings

### DIFF
--- a/locales/fi.json
+++ b/locales/fi.json
@@ -54,10 +54,10 @@
         "dont_see_address": "En näe osoitettani"
     },
     "billing": {
-        "title": "Toimitus",
-        "address": "Toimitusosoite",
-        "continue_to_shipping": "Jatka toimitukseen",
-        "use_different_shipping_address": "Käytä erillistä toimitusosoitetta"
+        "title": "Laskutus",
+        "address": "Laskutusosoite",
+        "continue_to_shipping": "Jatka toimitustietoihin",
+        "use_different_shipping_address": "Käytä eri toimitusosoitetta"
     },
     "customer": {
         "information": "Asiakkaan tiedot"


### PR DESCRIPTION
mix-up in the logic of these Finnish translations. Usually, in an e-commerce checkout flow, the "Billing" section refers to the Laskutusosoite (Billing address), while the "Shipping" section refers to the Toimitusosoite (Shipping address).